### PR TITLE
Use gmod_load_cvterms.pl to avoid duplicate keys errors

### DIFF
--- a/load.conf.tt2
+++ b/load.conf.tt2
@@ -43,7 +43,7 @@
   <!-- ontologies -->
   <!--            -->
   <ontology name="Relationship Ontology" order="1">
-    <file type="obo"    local="obo/OBO_REL/ro.obo" remote="https://raw.githubusercontent.com/abretaud/obo-relations/master/subsets/ro-chado.obo" method="lwp-mirror"/>
+    <file type="obo"    local="obo/OBO_REL/ro.obo" remote="https://raw.githubusercontent.com/oborel/obo-relations/master/subsets/ro-chado.obo" method="lwp-mirror"/>
   </ontology>
 
 


### PR DESCRIPTION
To workaround the recurring duplicate keys error, we can use `gmod_load_cvterms.pl` to load ontologies instead of `make ontologies`.
It is written to update ontologies, so everything should load without error now (finger crossed). I _think_ it should give the same result.

I'm still fighting to populate the cvtermpath table once the ontology is loaded (because I will need it), but that's another problem...
