### PR TITLE
Populate the cvtermpath table + temp fix RO url

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,5 +40,6 @@ ENV GMOD_ROOT /usr/share/gmod/
 RUN mkdir -p $GMOD_ROOT /build
 WORKDIR /build
 ADD load.conf.tt2 /opt/load.conf.tt2
+ADD cvtermpath_fix.sql /opt/cvtermpath_fix.sql
 
 ADD build.sh /docker-entrypoint-initdb.d/build.sh

--- a/build.sh
+++ b/build.sh
@@ -30,6 +30,16 @@ gmod_load_cvterms.pl -s SOFP load/etc/feature_property.obo
 gmod_load_cvterms.pl -s PO /build/po.obo
 gmod_load_cvterms.pl -s TAXRANK /build/taxrank.obo
 
+# Populate cvtermpath table
+psql -h localhost -p 5432 -U postgres < /opt/cvtermpath_fix.sql
+echo "select * from fill_cvtermpath('sequence');" | psql -U postgres
+echo "select * from fill_cvtermpath('plant_anatomy');" | psql -U postgres
+echo "select * from fill_cvtermpath('plant_structure_development_stage');" | psql -U postgres
+echo "select * from fill_cvtermpath('taxonomic_rank');" | psql -U postgres
+echo "select * from fill_cvtermpath('biological_process');" | psql -U postgres
+echo "select * from fill_cvtermpath('molecular_function');" | psql -U postgres
+echo "select * from fill_cvtermpath('cellular_component');" | psql -U postgres
+
 pg_dump -h localhost -p 5432 -U postgres --no-owner --no-acl postgres > "/host/chado-${VERSION}.sql"
 psql -h localhost -p 5432 -U postgres -c 'ALTER SCHEMA public RENAME TO chado'
 pg_dump -h localhost -p 5432 -U postgres --no-owner --no-acl postgres > "/host/chado-${VERSION}-tripal.sql"

--- a/build.sh
+++ b/build.sh
@@ -32,13 +32,13 @@ gmod_load_cvterms.pl -s TAXRANK /build/taxrank.obo
 
 # Populate cvtermpath table
 psql -h localhost -p 5432 -U postgres < /opt/cvtermpath_fix.sql
-echo "select * from fill_cvtermpath('sequence');" | psql -U postgres
-echo "select * from fill_cvtermpath('plant_anatomy');" | psql -U postgres
-echo "select * from fill_cvtermpath('plant_structure_development_stage');" | psql -U postgres
-echo "select * from fill_cvtermpath('taxonomic_rank');" | psql -U postgres
-echo "select * from fill_cvtermpath('biological_process');" | psql -U postgres
-echo "select * from fill_cvtermpath('molecular_function');" | psql -U postgres
-echo "select * from fill_cvtermpath('cellular_component');" | psql -U postgres
+echo "select * from fill_cvtermpath('sequence');" | psql -h localhost -p 5432 -U postgres
+echo "select * from fill_cvtermpath('plant_anatomy');" | psql -h localhost -p 5432 -U postgres
+echo "select * from fill_cvtermpath('plant_structure_development_stage');" | psql -h localhost -p 5432 -U postgres
+echo "select * from fill_cvtermpath('taxonomic_rank');" | psql -h localhost -p 5432 -U postgres
+echo "select * from fill_cvtermpath('biological_process');" | psql -h localhost -p 5432 -U postgres
+echo "select * from fill_cvtermpath('molecular_function');" | psql -h localhost -p 5432 -U postgres
+echo "select * from fill_cvtermpath('cellular_component');" | psql -h localhost -p 5432 -U postgres
 
 pg_dump -h localhost -p 5432 -U postgres --no-owner --no-acl postgres > "/host/chado-${VERSION}.sql"
 psql -h localhost -p 5432 -U postgres -c 'ALTER SCHEMA public RENAME TO chado'

--- a/cvtermpath_fix.sql
+++ b/cvtermpath_fix.sql
@@ -1,0 +1,74 @@
+--- example: select * from fill_cvtermpath(7); where 7 is cv_id for an ontology
+--- fill path from the node to its children and their children
+CREATE OR REPLACE FUNCTION _fill_cvtermpath4node(BIGINT, BIGINT, BIGINT, BIGINT, INTEGER, BIGINT[]) RETURNS INTEGER AS
+'
+DECLARE
+    origin alias for $1;
+    child_id alias for $2;
+    cvid alias for $3;
+    typeid alias for $4;
+    depth alias for $5;
+    forbidden_rels alias for $6;
+    cterm cvterm_relationship%ROWTYPE;
+    exist_c int;
+
+BEGIN
+
+    --- RAISE NOTICE ''depth=% root=%'', depth,child_id;
+    --- not check type_id as it may be null and not very meaningful in cvtermpath when pathdistance > 1
+    SELECT INTO exist_c count(*) FROM cvtermpath WHERE cv_id = cvid AND object_id = origin AND subject_id = child_id AND pathdistance = depth;
+
+    IF (exist_c = 0) THEN
+        INSERT INTO cvtermpath (object_id, subject_id, cv_id, type_id, pathdistance) VALUES(origin, child_id, cvid, typeid, depth);
+    END IF;
+    FOR cterm IN SELECT * FROM cvterm_relationship WHERE object_id = child_id and type_id <> ALL(forbidden_rels) LOOP
+        PERFORM _fill_cvtermpath4node(origin, cterm.subject_id, cvid, cterm.type_id, depth+1, forbidden_rels);
+    END LOOP;
+    RETURN 1;
+END;
+'
+LANGUAGE 'plpgsql';
+
+CREATE OR REPLACE FUNCTION _fill_cvtermpath4root(BIGINT, BIGINT, BIGINT[]) RETURNS INTEGER AS
+'
+DECLARE
+    rootid alias for $1;
+    cvid alias for $2;
+    forbidden_rels alias for $3;
+    ttype bigint;
+    cterm cvterm_relationship%ROWTYPE;
+    child cvterm_relationship%ROWTYPE;
+
+BEGIN
+
+    SELECT INTO ttype cvterm_id FROM cvterm WHERE (name = ''isa'' OR name = ''is_a'');
+    PERFORM _fill_cvtermpath4node(rootid, rootid, cvid, ttype, 0, forbidden_rels);
+    FOR cterm IN SELECT * FROM cvterm_relationship WHERE object_id = rootid and type_id <> ALL(forbidden_rels) LOOP
+        PERFORM _fill_cvtermpath4root(cterm.subject_id, cvid, forbidden_rels);
+        -- RAISE NOTICE ''DONE for term, %'', cterm.subject_id;
+    END LOOP;
+    RETURN 1;
+END;
+'
+LANGUAGE 'plpgsql';
+
+CREATE OR REPLACE FUNCTION fill_cvtermpath(BIGINT) RETURNS INTEGER AS
+'
+DECLARE
+    cvid alias for $1;
+    root cvterm%ROWTYPE;
+    forbidden_rels bigint[];
+
+BEGIN
+
+    DELETE FROM cvtermpath WHERE cv_id = cvid;
+
+    SELECT INTO forbidden_rels array(SELECT cvterm_id FROM cvterm WHERE (name = ''HAS_PART'' OR name = ''has_part'' OR name = ''preceded_by'' OR name = ''PRECEDED_BY''));
+
+    FOR root IN SELECT DISTINCT t.* from cvterm t LEFT JOIN cvterm_relationship r ON (t.cvterm_id = r.subject_id) INNER JOIN cvterm_relationship r2 ON (t.cvterm_id = r2.object_id) WHERE t.cv_id = cvid AND r.subject_id is null LOOP
+        PERFORM _fill_cvtermpath4root(root.cvterm_id, root.cv_id, forbidden_rels);
+    END LOOP;
+    RETURN 1;
+END;
+'
+LANGUAGE 'plpgsql';

--- a/load.conf.tt2
+++ b/load.conf.tt2
@@ -43,7 +43,7 @@
   <!-- ontologies -->
   <!--            -->
   <ontology name="Relationship Ontology" order="1">
-    <file type="obo"    local="obo/OBO_REL/ro.obo" remote="https://raw.githubusercontent.com/oborel/obo-relations/master/subsets/ro-chado.obo" method="lwp-mirror"/>
+    <file type="obo"    local="obo/OBO_REL/ro.obo" remote="https://raw.githubusercontent.com/abretaud/obo-relations/master/subsets/ro-chado.obo" method="lwp-mirror"/>
   </ontology>
 
 


### PR DESCRIPTION
Ok, 2 new things:
- first, until there is a new release for obo-relations, I switched back to my fork, it should fix the error we had in the last build. I have (and I will probably fail) to remember to change back to oborel later.
- also I finally found a way to populate the cvtermpath table. It kept crashing because it found some ontologies (GO, ...) did not appear to be proper DAGs. This was due to the part_of and has_part relations which _looks_ circular (A is part_of B, and B has_part A). I just changed the function to ignore the has_part counterpart of part_of. I don't know if this could/should be included as is in the chado code, what do you think @scottcain?

Anyway, let's try this and cross fingers! (I couldn't test the whole process)
