### PR TITLE
Backport fix from https://github.com/GMOD/Chado/pull/105

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Chado Schema Builder
 
+[![Build Status](https://build.galaxyproject.eu/buildStatus/icon?job=usegalaxy-eu%2Fchado-schema-builder)](https://build.galaxyproject.eu/job/usegalaxy-eu/job/chado-schema-builder/)
+
 This project provides a dockerfile to automatically build the chado database
 dumps. These schema dumps are necessary due to how much time and memory the
 process of parsing ontologies takes. For older machines such as the author's


### PR DESCRIPTION
Tested pgtools stuff in Galaxy, and got this fatal error:
```
Fatal error: 
psql:/export/galaxy-central/database/files/000/dataset_1.dat:2480464: ERROR:  function create_point(integer, bigint) does not exist
LINE 1: SELECT box (create_point(0, $1), create_point($2,500000000))
                    ^
HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
QUERY:  SELECT box (create_point(0, $1), create_point($2,500000000))
CONTEXT:  SQL function "boxrange" during inlining
```

So backporting a fix from https://github.com/GMOD/Chado/pull/105
Trying to test it locally, but I think building is very long(?)