### PR TITLE
Rename repo

### DIFF
--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -11,7 +11,7 @@ make;
 docker run \
 	-e BRANCH=$VERSION \
 	-e DBSTAG_TRACE=1 \
-	erasche/chado-schema-builder;
+	hexylena/chado-schema-builder;
 # This will likely fail! But that's OK.
 retcode=$?
 # Because if it exits with code 42 then we built the image successfully (or hit some very strange error ;))
@@ -20,7 +20,7 @@ if [ $retcode -eq 42 ]; then
 	# hacky but since we're checking exit code above it's hard to figure
 	# another way to do this. We should probably move to launching it in the
 	# background and then polling it continuously.
-	CONTAINER_ID=$(docker ps -a  |grep erasche/chado-schema-builder | head -n 1 | cut -c1-12);
+	CONTAINER_ID=$(docker ps -a  |grep hexylena/chado-schema-builder | head -n 1 | cut -c1-12);
 	# And copy the files out of it
 	docker cp ${CONTAINER_ID}:/build/chado-${VERSION}-no-onto.sql.gz chado-${VERSION}-no-onto.sql.gz
 	docker cp ${CONTAINER_ID}:/build/chado-${VERSION}.sql.gz chado-${VERSION}.sql.gz

--- a/.ci/upload.sh
+++ b/.ci/upload.sh
@@ -11,4 +11,4 @@ if [ ! -e ghr  ]; then
 fi
 
 CHADO_VERSION=$(find "output" | grep -o 'chado-[/0-9.]*.sql.gz' | sed 's/chado-//g;s/\.sql\.gz//g;')
-./ghr -u erasche -r chado-schema-builder "${CHADO_VERSION}-jenkins${BUILD_ID}" output
+./ghr -u hexylena -r chado-schema-builder "${CHADO_VERSION}-jenkins${BUILD_ID}" output

--- a/Dockerfile.inherit
+++ b/Dockerfile.inherit
@@ -1,4 +1,4 @@
-FROM quay.io/erasche/chado-schema-builder-base:latest
+FROM quay.io/hexylena/chado-schema-builder-base:latest
 
 RUN mkdir -p $GMOD_ROOT /build && \
     chown postgres:postgres /build

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 build_container: build.sh Dockerfile
-	docker build -t erasche/chado-schema-builder --file Dockerfile.inherit .
+	docker build -t hexylena/chado-schema-builder --file Dockerfile.inherit .
 
 schema: build_container
-	docker run -it --rm --volume=$(shell pwd)/output:/host -e BRANCH=1.31 erasche/chado-schema-builder
+	docker run -it --rm --volume=$(shell pwd)/output:/host -e BRANCH=1.31 hexylena/chado-schema-builder
 
 .PHONY: schema build_container


### PR DESCRIPTION
The schedule jenkins job seems to fail due to the repo renaming, so adapting the ci code + :crossed_fingers: 
Can you have a look at restarting the jenkins build after merge @hexylena?